### PR TITLE
텍스트 파싱 관련 API 로직 추가

### DIFF
--- a/__mocks__/handlers.ts
+++ b/__mocks__/handlers.ts
@@ -2,6 +2,7 @@ import { http, HttpResponse } from 'msw'
 import { postHandlers } from '@/entities/announcement'
 import { badgeHandlers } from '@/entities/attendance-badge'
 import { attendanceHandlers } from '@/entities/attendance-option'
+import { textParsingHandlers } from '@/entities/text-parsing'
 
 export const handlers = [
   http.get(`${process.env.NEXT_PUBLIC_DOMAIN_ADDRESS}/api/mock-test`, () => {
@@ -10,4 +11,5 @@ export const handlers = [
   ...postHandlers,
   ...attendanceHandlers,
   ...badgeHandlers,
+  ...textParsingHandlers,
 ]

--- a/src/entities/attendance-badge/@x/text-parsing.ts
+++ b/src/entities/attendance-badge/@x/text-parsing.ts
@@ -1,0 +1,1 @@
+export { AttendanceBadgeSchema } from '../model'

--- a/src/entities/attendance-option/@x/text-parsing.ts
+++ b/src/entities/attendance-option/@x/text-parsing.ts
@@ -1,0 +1,1 @@
+export { AttendanceOptionKeySchema, AttendanceDetailOptionSchema } from '../model'

--- a/src/entities/attendance-option/api/get-option-list.ts
+++ b/src/entities/attendance-option/api/get-option-list.ts
@@ -5,13 +5,10 @@ import type { AttendanceOptionKey } from '../model'
 import { AttendanceOptionKeySchema, AttendanceOptionSchema } from '../model'
 import { ATTENDANCE_OPTION_ENDPOINT, ATTENDANCE_OPTION_TAG } from './endpoint'
 
-const AttendanceOptionKeys = Object.values(AttendanceOptionKeySchema.Values)
-
 export const GetAttendanceOptionsAllSchema = z.object(
-  Object.fromEntries(AttendanceOptionKeys.map((key) => [key, AttendanceOptionSchema])) as Record<
-    AttendanceOptionKey,
-    typeof AttendanceOptionSchema
-  >,
+  Object.fromEntries(
+    AttendanceOptionKeySchema.options.map((key) => [key, AttendanceOptionSchema]),
+  ) as Record<AttendanceOptionKey, typeof AttendanceOptionSchema>,
 )
 
 export type GetAttendanceOptionsAll = z.infer<typeof GetAttendanceOptionsAllSchema>

--- a/src/entities/attendance-option/api/mocks/create-detail-option.ts
+++ b/src/entities/attendance-option/api/mocks/create-detail-option.ts
@@ -3,6 +3,7 @@ import { PostAttendanceOptionBodySchema } from '../create-detail-option'
 import { ATTENDANCE_OPTION_ENDPOINT } from '../endpoint'
 import { AttendanceOptionKeySchema } from '../../model'
 import { OPTION_LIST_MOCK_DATA } from './option-list'
+import { createDetailOptionInTextParsingOptionMockData } from '@/entities/text-parsing/@x/attendance-option'
 
 export const createAttendanceDetailOptionMockHandler = createMockHandler({
   endpoint: ATTENDANCE_OPTION_ENDPOINT.PRIMARY(':optionKey'),
@@ -34,6 +35,8 @@ export const createAttendanceDetailOptionMockHandler = createMockHandler({
       allDetailOptions.length > 0 ? Math.max(...allDetailOptions.map((opt) => opt.id)) : 0
 
     OPTION_LIST_MOCK_DATA[optionKey].detailOptions.push({ id: maxId + 1, name })
+
+    createDetailOptionInTextParsingOptionMockData(maxId + 1, name)
 
     return { data: {} }
   },

--- a/src/entities/attendance-option/api/mocks/create-detail-option.ts
+++ b/src/entities/attendance-option/api/mocks/create-detail-option.ts
@@ -1,9 +1,9 @@
+import { createDetailOptionInTextParsingOptionMockData } from '@/entities/text-parsing/@x/attendance-option'
 import { createMockHandler } from '@/shared/api'
 import { PostAttendanceOptionBodySchema } from '../create-detail-option'
 import { ATTENDANCE_OPTION_ENDPOINT } from '../endpoint'
 import { AttendanceOptionKeySchema } from '../../model'
 import { OPTION_LIST_MOCK_DATA } from './option-list'
-import { createDetailOptionInTextParsingOptionMockData } from '@/entities/text-parsing/@x/attendance-option'
 
 export const createAttendanceDetailOptionMockHandler = createMockHandler({
   endpoint: ATTENDANCE_OPTION_ENDPOINT.PRIMARY(':optionKey'),

--- a/src/entities/attendance-option/api/mocks/delete-detail-option.ts
+++ b/src/entities/attendance-option/api/mocks/delete-detail-option.ts
@@ -1,9 +1,9 @@
 import { deleteBadgeDetailOptionInMockData } from '@/entities/attendance-badge/@x/attendance-option'
+import { deleteDetailOptionInTextParsingOptionMockData } from '@/entities/text-parsing/@x/attendance-option'
 import { createMockHandler } from '@/shared/api'
 import { ATTENDANCE_OPTION_ENDPOINT } from '../endpoint'
 import { AttendanceOptionKeySchema } from '../../model'
 import { OPTION_LIST_MOCK_DATA } from './option-list'
-import { deleteDetailOptionInTextParsingOptionMockData } from '@/entities/text-parsing/@x/attendance-option'
 
 export const deleteAttendanceDetailOptionMockHandler = createMockHandler({
   endpoint: ATTENDANCE_OPTION_ENDPOINT.DETAIL(':optionKey', ':detailOptionId'),

--- a/src/entities/attendance-option/api/mocks/delete-detail-option.ts
+++ b/src/entities/attendance-option/api/mocks/delete-detail-option.ts
@@ -3,6 +3,7 @@ import { createMockHandler } from '@/shared/api'
 import { ATTENDANCE_OPTION_ENDPOINT } from '../endpoint'
 import { AttendanceOptionKeySchema } from '../../model'
 import { OPTION_LIST_MOCK_DATA } from './option-list'
+import { deleteDetailOptionInTextParsingOptionMockData } from '@/entities/text-parsing/@x/attendance-option'
 
 export const deleteAttendanceDetailOptionMockHandler = createMockHandler({
   endpoint: ATTENDANCE_OPTION_ENDPOINT.DETAIL(':optionKey', ':detailOptionId'),
@@ -32,6 +33,8 @@ export const deleteAttendanceDetailOptionMockHandler = createMockHandler({
     })
 
     if (hasDeletedTarget) {
+      deleteDetailOptionInTextParsingOptionMockData(targetId)
+
       return Promise.resolve({ data: {} })
     }
 

--- a/src/entities/attendance-option/api/mocks/delete-detail-option.ts
+++ b/src/entities/attendance-option/api/mocks/delete-detail-option.ts
@@ -25,6 +25,7 @@ export const deleteAttendanceDetailOptionMockHandler = createMockHandler({
       if (targetIndex !== -1) {
         OPTION_LIST_MOCK_DATA[optionKey].detailOptions.splice(targetIndex, 1)
         deleteBadgeDetailOptionInMockData(targetId)
+        deleteDetailOptionInTextParsingOptionMockData(targetId)
 
         return true
       }
@@ -33,8 +34,6 @@ export const deleteAttendanceDetailOptionMockHandler = createMockHandler({
     })
 
     if (hasDeletedTarget) {
-      deleteDetailOptionInTextParsingOptionMockData(targetId)
-
       return Promise.resolve({ data: {} })
     }
 

--- a/src/entities/attendance-option/api/mocks/modify-detail-option.ts
+++ b/src/entities/attendance-option/api/mocks/modify-detail-option.ts
@@ -1,9 +1,9 @@
+import { updateDetailOptionInTextParsingOptionMockData } from '@/entities/text-parsing/@x/attendance-option'
 import { createMockHandler } from '@/shared/api'
 import { ATTENDANCE_OPTION_ENDPOINT } from '../endpoint'
 import { PutAttendanceOptionBodySchema } from '../modify-detail-option'
 import { AttendanceOptionKeySchema } from '../../model'
 import { OPTION_LIST_MOCK_DATA } from './option-list'
-import { updateDetailOptionInTextParsingOptionMockData } from '@/entities/text-parsing/@x/attendance-option'
 
 export const modifyAttendanceDetailOptionMockHandler = createMockHandler({
   endpoint: ATTENDANCE_OPTION_ENDPOINT.DETAIL(':optionKey', ':detailOptionId'),

--- a/src/entities/attendance-option/api/mocks/modify-detail-option.ts
+++ b/src/entities/attendance-option/api/mocks/modify-detail-option.ts
@@ -3,6 +3,7 @@ import { ATTENDANCE_OPTION_ENDPOINT } from '../endpoint'
 import { PutAttendanceOptionBodySchema } from '../modify-detail-option'
 import { AttendanceOptionKeySchema } from '../../model'
 import { OPTION_LIST_MOCK_DATA } from './option-list'
+import { updateDetailOptionInTextParsingOptionMockData } from '@/entities/text-parsing/@x/attendance-option'
 
 export const modifyAttendanceDetailOptionMockHandler = createMockHandler({
   endpoint: ATTENDANCE_OPTION_ENDPOINT.DETAIL(':optionKey', ':detailOptionId'),
@@ -41,6 +42,8 @@ export const modifyAttendanceDetailOptionMockHandler = createMockHandler({
     })
 
     if (hasModifiedTarget) {
+      updateDetailOptionInTextParsingOptionMockData(targetId, name)
+
       return { data: {} }
     }
 

--- a/src/entities/attendance-option/api/modify-detail-option.ts
+++ b/src/entities/attendance-option/api/modify-detail-option.ts
@@ -11,7 +11,7 @@ export type PutAttendanceOptionsBody = z.infer<typeof PutAttendanceOptionBodySch
 
 export const PutAttendanceOptionParamsSchema = z.object({
   optionKey: AttendanceOptionKeySchema,
-  detailOptionId: AttendanceDetailOptionSchema.transform((val) => val.id),
+  detailOptionId: AttendanceDetailOptionSchema.shape.id,
   body: PutAttendanceOptionBodySchema,
 })
 

--- a/src/entities/text-parsing/@x/attendance-option.ts
+++ b/src/entities/text-parsing/@x/attendance-option.ts
@@ -1,0 +1,25 @@
+import { PARSING_OPTIONS_MOCK_DATA } from '../api/mocks/parsing-options'
+
+export const createDetailOptionInTextParsingOptionMockData = (id: number, name: string) => {
+  PARSING_OPTIONS_MOCK_DATA.attendanceDetailOptions.push({
+    id,
+    name,
+    identifier: name,
+  })
+}
+
+export const updateDetailOptionInTextParsingOptionMockData = (id: number, name: string) => {
+  PARSING_OPTIONS_MOCK_DATA.attendanceDetailOptions.forEach((detailOption) => {
+    if (detailOption.id === id) {
+      detailOption.name = name
+      detailOption.identifier = name
+    }
+  })
+}
+
+export const deleteDetailOptionInTextParsingOptionMockData = (id: number) => {
+  PARSING_OPTIONS_MOCK_DATA.attendanceDetailOptions =
+    PARSING_OPTIONS_MOCK_DATA.attendanceDetailOptions.filter(
+      (detailOption) => detailOption.id !== id,
+    )
+}

--- a/src/entities/text-parsing/@x/attendance-option.ts
+++ b/src/entities/text-parsing/@x/attendance-option.ts
@@ -9,10 +9,10 @@ export const createDetailOptionInTextParsingOptionMockData = (id: number, name: 
 }
 
 export const updateDetailOptionInTextParsingOptionMockData = (id: number, name: string) => {
-  PARSING_OPTIONS_MOCK_DATA.attendanceDetailOptions.forEach((detailOption) => {
+  PARSING_OPTIONS_MOCK_DATA.attendanceDetailOptions.forEach((detailOption, detailOptionIdx) => {
     if (detailOption.id === id) {
-      detailOption.name = name
-      detailOption.identifier = name
+      PARSING_OPTIONS_MOCK_DATA.attendanceDetailOptions[detailOptionIdx].name = name
+      PARSING_OPTIONS_MOCK_DATA.attendanceDetailOptions[detailOptionIdx].identifier = name
     }
   })
 }

--- a/src/entities/text-parsing/api/create-parsing-result.ts
+++ b/src/entities/text-parsing/api/create-parsing-result.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod'
+import { server } from '@/shared/api'
+import { ParsingResultSchema } from './../model/schema'
+import { TEXT_PARSING_ENDPOINT } from './endpoint'
+
+export const PostParsingResultBodySchema = z.array(
+  ParsingResultSchema.omit({ attendanceStatistic: true }),
+)
+
+export type PostParsingResult = z.infer<typeof PostParsingResultBodySchema>
+
+export const createParsingResult = (teamId: number, body: PostParsingResult) =>
+  server.request(TEXT_PARSING_ENDPOINT.RESULT(teamId), {
+    schema: z.any(),
+    body: JSON.stringify(body),
+    method: 'POST',
+  })

--- a/src/entities/text-parsing/api/endpoint.ts
+++ b/src/entities/text-parsing/api/endpoint.ts
@@ -5,4 +5,4 @@ export const TEXT_PARSING_ENDPOINT = {
 
 export const TEXT_PARSING_TAG = {
   PARSING_OPTIONS: 'text-parsing-options',
-}
+} as const

--- a/src/entities/text-parsing/api/endpoint.ts
+++ b/src/entities/text-parsing/api/endpoint.ts
@@ -1,0 +1,8 @@
+export const TEXT_PARSING_ENDPOINT = {
+  PARSING_OPTIONS: '/api/v1/attendance/parse-options',
+  RESULT: (teamId: string | number) => `/api/v1/attendance/teams/${teamId}/history` as const,
+} as const
+
+export const TEXT_PARSING_TAG = {
+  PARSING_OPTIONS: 'text-parsing-options',
+}

--- a/src/entities/text-parsing/api/endpoint.ts
+++ b/src/entities/text-parsing/api/endpoint.ts
@@ -1,5 +1,5 @@
 export const TEXT_PARSING_ENDPOINT = {
-  PARSING_OPTIONS: '/api/v1/attendance/parse-options',
+  PARSING_OPTIONS: '/api/v1/attendance/parsing-options',
   RESULT: (teamId: string | number) => `/api/v1/attendance/teams/${teamId}/history` as const,
 } as const
 

--- a/src/entities/text-parsing/api/get-parsing-options.ts
+++ b/src/entities/text-parsing/api/get-parsing-options.ts
@@ -1,0 +1,16 @@
+import type { z } from 'zod'
+import type { CommonResponse } from '@/shared/api'
+import { server } from '@/shared/api'
+import { ParsingOptionsSchema } from '../model/schema'
+import { TEXT_PARSING_ENDPOINT } from './endpoint'
+
+export const GetParsingOptionsSchema = ParsingOptionsSchema
+
+export type GetParsingOptions = z.infer<typeof GetParsingOptionsSchema>
+
+export type GetParsingOptionsResponse = CommonResponse<typeof GetParsingOptionsSchema>
+
+export const getParsingOptions = () =>
+  server.request(TEXT_PARSING_ENDPOINT.PARSING_OPTIONS, {
+    schema: GetParsingOptionsSchema,
+  })

--- a/src/entities/text-parsing/api/get-parsing-options.ts
+++ b/src/entities/text-parsing/api/get-parsing-options.ts
@@ -2,7 +2,7 @@ import type { z } from 'zod'
 import type { CommonResponse } from '@/shared/api'
 import { server } from '@/shared/api'
 import { ParsingOptionsSchema } from '../model/schema'
-import { TEXT_PARSING_ENDPOINT } from './endpoint'
+import { TEXT_PARSING_ENDPOINT, TEXT_PARSING_TAG } from './endpoint'
 
 export const GetParsingOptionsSchema = ParsingOptionsSchema
 
@@ -13,4 +13,7 @@ export type GetParsingOptionsResponse = CommonResponse<typeof GetParsingOptionsS
 export const getParsingOptions = () =>
   server.request(TEXT_PARSING_ENDPOINT.PARSING_OPTIONS, {
     schema: GetParsingOptionsSchema,
+    next: {
+      tags: [TEXT_PARSING_TAG.PARSING_OPTIONS],
+    },
   })

--- a/src/entities/text-parsing/api/index.ts
+++ b/src/entities/text-parsing/api/index.ts
@@ -1,0 +1,5 @@
+export * from './mocks'
+export * from './create-parsing-result'
+export * from './endpoint'
+export * from './get-parsing-options'
+export * from './modify-parsing-options'

--- a/src/entities/text-parsing/api/mocks/index.ts
+++ b/src/entities/text-parsing/api/mocks/index.ts
@@ -1,0 +1,9 @@
+import { modifyParsingOptionsMockHandler } from './modify-parsing-options'
+import { parsingOptionsMockHandler } from './parsing-options'
+import { postParsingResultMockHandler } from './parsing-result'
+
+export const textParsingHandlers = [
+  parsingOptionsMockHandler,
+  modifyParsingOptionsMockHandler,
+  postParsingResultMockHandler,
+]

--- a/src/entities/text-parsing/api/mocks/modify-parsing-options.ts
+++ b/src/entities/text-parsing/api/mocks/modify-parsing-options.ts
@@ -1,0 +1,22 @@
+import { createMockHandler } from '@/shared/api'
+import { TEXT_PARSING_ENDPOINT } from '../endpoint'
+import { ParsingOptionsSchema } from '../../model'
+import { PARSING_OPTIONS_MOCK_DATA } from './parsing-options'
+
+export const modifyParsingOptionsMockHandler = createMockHandler({
+  endpoint: TEXT_PARSING_ENDPOINT.PARSING_OPTIONS,
+  handler: async ({ request }) => {
+    const body = await request.json()
+    const { data } = ParsingOptionsSchema.safeParse(body)
+
+    if (!data) {
+      return { status: 400 }
+    }
+
+    Object.assign(PARSING_OPTIONS_MOCK_DATA, data)
+
+    return { data: {} }
+  },
+  method: 'put',
+  delay: 1_200,
+})

--- a/src/entities/text-parsing/api/mocks/parsing-options.ts
+++ b/src/entities/text-parsing/api/mocks/parsing-options.ts
@@ -24,6 +24,16 @@ export const PARSING_OPTIONS_MOCK_DATA: GetParsingOptionsResponse['data'] = {
       name: '5시간 이상 출석',
       identifier: '5시간 이상 출석',
     },
+    {
+      id: 2,
+      name: '운영진 휴가',
+      identifier: '운영진 휴가',
+    },
+    {
+      id: 3,
+      name: '열정멤버 휴가',
+      identifier: '열정멤버 휴가',
+    },
   ],
 }
 

--- a/src/entities/text-parsing/api/mocks/parsing-options.ts
+++ b/src/entities/text-parsing/api/mocks/parsing-options.ts
@@ -1,0 +1,34 @@
+import type { GetParsingOptionsResponse } from '../get-parsing-options'
+import { createMockHandler } from '@/shared/api'
+import { TEXT_PARSING_ENDPOINT } from '../endpoint'
+
+export const PARSING_OPTIONS_MOCK_DATA: GetParsingOptionsResponse['data'] = {
+  delimiter: {
+    person: '-',
+    line: '\n',
+    title: ':',
+  },
+  dayMapping: {
+    monday: '월',
+    tuesday: '화',
+    wednesday: '수',
+    thursday: '목',
+    friday: '금',
+    saturday: '토',
+    sunday: '일',
+  },
+  name: '이름',
+  attendanceDetailOptions: [
+    {
+      id: 1,
+      name: '5시간 이상 출석',
+      identifier: '5시간 이상 출석',
+    },
+  ],
+}
+
+export const parsingOptionsMockHandler = createMockHandler<GetParsingOptionsResponse['data']>({
+  endpoint: TEXT_PARSING_ENDPOINT.PARSING_OPTIONS,
+  handler: () => Promise.resolve({ data: PARSING_OPTIONS_MOCK_DATA }),
+  delay: 300,
+})

--- a/src/entities/text-parsing/api/mocks/parsing-result.ts
+++ b/src/entities/text-parsing/api/mocks/parsing-result.ts
@@ -1,0 +1,26 @@
+import { createMockHandler } from '@/shared/api'
+import { PostParsingResultBodySchema } from '../create-parsing-result'
+import { TEXT_PARSING_ENDPOINT } from '../endpoint'
+
+export const postParsingResultMockHandler = createMockHandler({
+  endpoint: TEXT_PARSING_ENDPOINT.RESULT(':teamId'),
+  handler: async ({ request, params }) => {
+    const body = await request.json()
+
+    const { data } = PostParsingResultBodySchema.safeParse(body)
+
+    if (!data) {
+      return { status: 400 }
+    }
+
+    const teamId = Number(params.teamId)
+
+    if (Number.isNaN(teamId)) {
+      return { status: 400 }
+    }
+
+    return { data: {} }
+  },
+  method: 'post',
+  delay: 1_200,
+})

--- a/src/entities/text-parsing/api/modify-parsing-options.revalidate.ts
+++ b/src/entities/text-parsing/api/modify-parsing-options.revalidate.ts
@@ -1,0 +1,7 @@
+'use server'
+
+import { revalidateTag } from 'next/cache'
+import { TEXT_PARSING_TAG } from './endpoint'
+
+export const modifyTextParsingOptionsWithRevalidate = async () =>
+  [TEXT_PARSING_TAG.PARSING_OPTIONS].forEach(revalidateTag)

--- a/src/entities/text-parsing/api/modify-parsing-options.ts
+++ b/src/entities/text-parsing/api/modify-parsing-options.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod'
+import { server } from '@/shared/api'
+import { ParsingOptionsSchema } from '../model/schema'
+import { TEXT_PARSING_ENDPOINT } from './endpoint'
+
+export const PutParsingOptionsBodySchema = ParsingOptionsSchema
+
+export type PutParsingOptionsBody = z.infer<typeof PutParsingOptionsBodySchema>
+
+export const modifyParsingOptions = (body: PutParsingOptionsBody) =>
+  server.request(TEXT_PARSING_ENDPOINT.PARSING_OPTIONS, {
+    schema: z.any(),
+    body: JSON.stringify(body),
+    method: 'PUT',
+  })

--- a/src/entities/text-parsing/index.ts
+++ b/src/entities/text-parsing/index.ts
@@ -1,0 +1,2 @@
+export * from './api'
+export * from './model'

--- a/src/entities/text-parsing/model/index.ts
+++ b/src/entities/text-parsing/model/index.ts
@@ -1,0 +1,1 @@
+export * from './schema'

--- a/src/entities/text-parsing/model/schema.ts
+++ b/src/entities/text-parsing/model/schema.ts
@@ -1,0 +1,72 @@
+import { z } from 'zod'
+import { AttendanceBadgeSchema } from '@/entities/attendance-badge/@x/text-parsing'
+import {
+  AttendanceDetailOptionSchema,
+  AttendanceOptionKeySchema,
+} from '@/entities/attendance-option/@x/text-parsing'
+
+export const DelimiterKeySchema = z.enum(['person', 'line', 'title'])
+
+export type DelimiterKey = z.infer<typeof DelimiterKeySchema>
+
+export const DayKeySchema = z.enum([
+  'monday',
+  'tuesday',
+  'wednesday',
+  'thursday',
+  'friday',
+  'saturday',
+  'sunday',
+])
+
+export type DayKey = z.infer<typeof DayKeySchema>
+
+export const AttendanceDetailExtractOptionsSchema = AttendanceDetailOptionSchema.extend({
+  identifier: z.string(),
+})
+
+export type AttendanceDetailExtractOptions = z.infer<typeof AttendanceDetailExtractOptionsSchema>
+
+export const ParsingOptionsSchema = z.object({
+  delimiter: z.object(
+    Object.fromEntries(DelimiterKeySchema.options.map((key) => [key, z.string()])) as Record<
+      DelimiterKey,
+      z.ZodString
+    >,
+  ),
+  dayMapping: z.object(
+    Object.fromEntries(DayKeySchema.options.map((key) => [key, z.string()])) as Record<
+      DayKey,
+      z.ZodString
+    >,
+  ),
+  name: z.string(),
+  attendanceDetailOptions: z.array(AttendanceDetailExtractOptionsSchema),
+})
+
+export type ParsingOption = z.infer<typeof ParsingOptionsSchema>
+
+export const AttendanceInfoValueSchema = z.object({
+  key: AttendanceOptionKeySchema,
+  detailId: AttendanceDetailOptionSchema.shape.id.optional(),
+})
+
+export type AttendanceInfoValue = z.infer<typeof AttendanceInfoValueSchema>
+
+export const ParsingResultSchema = z.object({
+  name: z.string(),
+  badgeId: AttendanceBadgeSchema.shape.id,
+  attendanceInfo: z.object(
+    Object.fromEntries(
+      DayKeySchema.options.map((key) => [key, AttendanceInfoValueSchema]),
+    ) as Record<DayKey, typeof AttendanceInfoValueSchema>,
+  ),
+  attendanceStatistic: z.array(
+    z.record(
+      z.union([AttendanceOptionKeySchema, AttendanceDetailOptionSchema.shape.id]),
+      z.number(),
+    ),
+  ),
+})
+
+export type ParsingResult = z.infer<typeof ParsingResultSchema>

--- a/src/entities/text-parsing/model/schema.ts
+++ b/src/entities/text-parsing/model/schema.ts
@@ -21,11 +21,13 @@ export const DayKeySchema = z.enum([
 
 export type DayKey = z.infer<typeof DayKeySchema>
 
-export const AttendanceDetailExtractOptionsSchema = AttendanceDetailOptionSchema.extend({
+export const AttendanceDetailWithExtractOptionSchema = AttendanceDetailOptionSchema.extend({
   identifier: z.string(),
 })
 
-export type AttendanceDetailExtractOptions = z.infer<typeof AttendanceDetailExtractOptionsSchema>
+export type AttendanceDetailWithExtractOption = z.infer<
+  typeof AttendanceDetailWithExtractOptionSchema
+>
 
 export const ParsingOptionsSchema = z.object({
   delimiter: z.object(
@@ -41,10 +43,10 @@ export const ParsingOptionsSchema = z.object({
     >,
   ),
   name: z.string(),
-  attendanceDetailOptions: z.array(AttendanceDetailExtractOptionsSchema),
+  attendanceDetailOptions: z.array(AttendanceDetailWithExtractOptionSchema),
 })
 
-export type ParsingOption = z.infer<typeof ParsingOptionsSchema>
+export type ParsingOptions = z.infer<typeof ParsingOptionsSchema>
 
 export const AttendanceInfoValueSchema = z.object({
   key: AttendanceOptionKeySchema,
@@ -52,6 +54,14 @@ export const AttendanceInfoValueSchema = z.object({
 })
 
 export type AttendanceInfoValue = z.infer<typeof AttendanceInfoValueSchema>
+
+export const AttendanceStatisticValue = z.object({
+  key: AttendanceOptionKeySchema,
+  detailId: AttendanceDetailOptionSchema.shape.id.optional(),
+  count: z.number(),
+})
+
+export type AttendanceStatisticValue = z.infer<typeof AttendanceStatisticValue>
 
 export const ParsingResultSchema = z.object({
   name: z.string(),
@@ -61,12 +71,7 @@ export const ParsingResultSchema = z.object({
       DayKeySchema.options.map((key) => [key, AttendanceInfoValueSchema]),
     ) as Record<DayKey, typeof AttendanceInfoValueSchema>,
   ),
-  attendanceStatistic: z.array(
-    z.record(
-      z.union([AttendanceOptionKeySchema, AttendanceDetailOptionSchema.shape.id]),
-      z.number(),
-    ),
-  ),
+  attendanceStatistic: z.array(AttendanceStatisticValue),
 })
 
 export type ParsingResult = z.infer<typeof ParsingResultSchema>


### PR DESCRIPTION
## 📑 PR 유형

<!-- 해당하는 유형에 X를 입력해주세요 (복수 가능) -->

- [ ] 🚨 버그 수정
- [x] 🔧 기능의 추가
- [ ] ✨ 코드 작성 양식의 변경 (포맷팅, 변수 이름 변경)
- [ ] 📚 리팩토링 (기능 또는 API 변경이 없는 경우)
- [ ] 🔨 빌드 관련 수정
- [ ] 💼 CI 관련 수정
- [ ] 📄 문서의 수정
- [ ] 🎸 기타

<br />

## 🌿 반영 브랜치 (리마인드 용도)

<!-- ex) feature/login => dev -->

```
feature/text-parsing => dev
```

<br />

## 🎨 작업 내용
- 텍스트 파싱 관련 스키마 작성
- 텍스트 파싱 관련 API 로직 작성
  - 텍스트 파싱 옵션 조회
  - 텍스트 파싱 옵션 수정 (+revalidate)
  - 텍스트 파싱 결과 저장
- 텍스트 파싱 관련 Mocking 로직 작성

<br />

## 🔑 관련 이슈 번호
[MOJI-22](https://itmoji.atlassian.net/browse/MOJI-22?atlOrigin=eyJpIjoiNjhmN2UzZGU3N2JlNGNkZWE5MTc5MmE1ZDllOTIzOTAiLCJwIjoiaiJ9)

<br />

## 🤝🏻 해당 부분을 중점적으로 리뷰해주세요!
- `parse-option`, `parsing-result` 등 `parse`가 다양한 형태로 이름에 포함되어 있었는데, 이를 `parsing`으로 통일하였습니다.
  - `parse-option`은 '옵션을 파싱하라'는 의미로 해석될 여지가 있어 `parsing`을 사용하는 것이 명확할 것 같습니다.
  - 따라서 텍스트 파싱 옵션 조회 및 수정 API 경로 또한 `/api/v1/attendance/parsing-options`로 수정되는 것이 좋을 것 같은데, 이와 관련한 의견을 코멘트로 남겨 주세요.

<br />


[MOJI-22]: https://itmoji.atlassian.net/browse/MOJI-22?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ