### PR TITLE
텍스트 파싱 관련 오동작 수정 및 배지 아이콘 복사 UI 추가

### DIFF
--- a/src/views/text-parsing/ui/text-parsing-options-setting.tsx
+++ b/src/views/text-parsing/ui/text-parsing-options-setting.tsx
@@ -53,6 +53,7 @@ export const TextParsingOptionsSetting: React.FC = () => {
 
   const handleApplyOptions = () => {
     setOptions(form.getValues())
+    form.resetTouched()
 
     parseTextSafely({
       text,
@@ -90,7 +91,7 @@ export const TextParsingOptionsSetting: React.FC = () => {
           <Button
             variant="light"
             onClick={handleApplyOptions}
-            disabled={!form.isDirty() || !text.trim() || isSubmitting}
+            disabled={!form.isTouched() || !text.trim() || isSubmitting}
           >
             적용하기
           </Button>

--- a/src/views/text-parsing/ui/text-parsing-result-form.tsx
+++ b/src/views/text-parsing/ui/text-parsing-result-form.tsx
@@ -38,7 +38,7 @@ export const TextParsingResultForm: React.FC<TextParsingResultFormProps> = ({
 
   const isSubmitting = useIsTextParsingMutating()
 
-  const { setInitialValues, ...form } = useForm({
+  const { setInitialValues, reset, ...form } = useForm({
     mode: 'controlled',
     initialValues: { result },
     enhanceGetInputProps: () => ({ disabled: isSubmitting }),
@@ -78,7 +78,8 @@ export const TextParsingResultForm: React.FC<TextParsingResultFormProps> = ({
 
   useEffect(() => {
     setInitialValues({ result })
-  }, [result, setInitialValues])
+    reset()
+  }, [result, setInitialValues, reset])
 
   return (
     <form

--- a/src/views/text-parsing/ui/text-parsing-result-form.tsx
+++ b/src/views/text-parsing/ui/text-parsing-result-form.tsx
@@ -1,6 +1,15 @@
 'use client'
 
-import { Group, Paper, Select, Table, TextInput, Title } from '@mantine/core'
+import {
+  ActionIcon,
+  CopyButton,
+  Group,
+  Paper,
+  Select,
+  Table,
+  TextInput,
+  Title,
+} from '@mantine/core'
 import { useForm } from '@mantine/form'
 import { useEffect } from 'react'
 import toast from 'react-hot-toast'
@@ -100,43 +109,60 @@ export const TextParsingResultForm: React.FC<TextParsingResultFormProps> = ({
               key={form.key(`result.${personIndex}.name`)}
               {...form.getInputProps(`result.${personIndex}.name`)}
             />
-            <Select
-              label={`적용 배지${form.isDirty(`result.${personIndex}.badgeId`) ? ' (동기화 해제됨)' : ''}`}
-              className="w-40"
-              classNames={{ label: 'mb-2 pt-0.5' }}
-              data={badgeOptions.map(({ id, name, icon }) => ({
-                value: id.toString(),
-                label: `${icon} ${name}`,
-              }))}
-              value={person.badgeId?.toString()}
-              onChange={(value) => {
-                const updatedBadgeId = Number(value)
-                const targetStatistic = transformAttendanceInfoToStatistic(
-                  person.attendanceInfo,
-                  attendanceOptions,
-                )
-                const computedBadgeId = getAttendanceBadgeId(targetStatistic, badgeOptions)
+            <Group gap="0.325rem" wrap="nowrap" align="flex-end">
+              <Select
+                label={`적용 배지${form.isDirty(`result.${personIndex}.badgeId`) ? ' (동기화 해제됨)' : ''}`}
+                className="w-40"
+                classNames={{ label: 'mb-2 pt-0.5' }}
+                data={badgeOptions.map(({ id, name, icon }) => ({
+                  value: id.toString(),
+                  label: `${icon} ${name}`,
+                }))}
+                value={person.badgeId?.toString()}
+                onChange={(value) => {
+                  const updatedBadgeId = Number(value)
+                  const targetStatistic = transformAttendanceInfoToStatistic(
+                    person.attendanceInfo,
+                    attendanceOptions,
+                  )
+                  const computedBadgeId = getAttendanceBadgeId(targetStatistic, badgeOptions)
 
-                if (updatedBadgeId === computedBadgeId) {
-                  setInitialValues({
-                    result: result.map((initialPerson) => {
-                      if (initialPerson.name === person.name) {
-                        return {
-                          ...initialPerson,
-                          badgeId: updatedBadgeId,
+                  if (updatedBadgeId === computedBadgeId) {
+                    setInitialValues({
+                      result: result.map((initialPerson) => {
+                        if (initialPerson.name === person.name) {
+                          return {
+                            ...initialPerson,
+                            badgeId: updatedBadgeId,
+                          }
                         }
-                      }
 
-                      return initialPerson
-                    }),
-                  })
-                }
+                        return initialPerson
+                      }),
+                    })
+                  }
 
-                form.setFieldValue(`result.${personIndex}.badgeId`, updatedBadgeId)
-              }}
-              checkIconPosition="right"
-              allowDeselect={false}
-            />
+                  form.setFieldValue(`result.${personIndex}.badgeId`, updatedBadgeId)
+                }}
+                checkIconPosition="right"
+                allowDeselect={false}
+              />
+              <CopyButton value={badgeOptions.find(({ id }) => id === person.badgeId)?.icon || ''}>
+                {({ copied, copy }) => (
+                  <ActionIcon
+                    title="배지 아이콘 복사하기"
+                    variant="default"
+                    size="input-sm"
+                    onClick={copy}
+                  >
+                    <Icon
+                      query={copied ? 'fluent:checkmark-16-regular' : 'fluent:copy-16-regular'}
+                      className="text-[var(--mantine-color-text)]"
+                    />
+                  </ActionIcon>
+                )}
+              </CopyButton>
+            </Group>
           </Group>
           <div className="mt-8 flex flex-col items-start gap-x-4 gap-y-8 @xl/parsing-result:flex-row">
             <div className="flex-1">


### PR DESCRIPTION
## 📑 PR 유형

<!-- 해당하는 유형에 X를 입력해주세요 (복수 가능) -->

- [x] 🚨 버그 수정
- [x] 🔧 기능의 추가
- [ ] ✨ 코드 작성 양식의 변경 (포맷팅, 변수 이름 변경)
- [ ] 📚 리팩토링 (기능 또는 API 변경이 없는 경우)
- [ ] 🔨 빌드 관련 수정
- [ ] 💼 CI 관련 수정
- [ ] 📄 문서의 수정
- [ ] 🎸 기타

<br />

## 🌿 반영 브랜치 (리마인드 용도)

<!-- ex) feature/login => dev -->

```
feature/text-parsing => dev
```

<br />

## 🎨 작업 내용
- 파싱 결과 배지 아이콘 복사 버튼 추가
- 파싱 옵션 수정 후 적용 시 분석 결과 폼 리렌더링되지 않는 문제 수정
- 파싱 옵션 설정 적용하기 버튼 비활성화 시점 수정 

<br />

## 🖥️ 실행 화면
[배지 아이콘 복사]

https://github.com/user-attachments/assets/8896b294-526d-47d5-a099-3f0405a23797


[수정 전]

https://github.com/user-attachments/assets/091ec745-c851-401b-ac36-3cad6c2c83bb

https://github.com/user-attachments/assets/813f804b-2055-45e8-980a-d0432d4a84b4

[수정 후]

https://github.com/user-attachments/assets/14aad841-a406-4a7e-bd0b-901c5b623e8a


<br />

## 🔑 관련 이슈 번호
[MOJI-32](https://itmoji.atlassian.net/browse/MOJI-32?atlOrigin=eyJpIjoiYzFmMTY3ODk5YjY1NDNmZTg2OWUyZGE5NTBmMjQyYWIiLCJwIjoiaiJ9)
[MOJI-33](https://itmoji.atlassian.net/browse/MOJI-33?atlOrigin=eyJpIjoiYjc2NjVmMjhjMTI5NDU1Y2I1ZDBhMTM2MWMxMWFlNWQiLCJwIjoiaiJ9)

<br />


[MOJI-32]: https://itmoji.atlassian.net/browse/MOJI-32?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MOJI-33]: https://itmoji.atlassian.net/browse/MOJI-33?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ