### PR TITLE
텍스트 파싱 결과 폼 사용성 개선을 위한 인풋/폼 초기화, 텍스트 파싱 예외 처리 기능 추가

### DIFF
--- a/src/entities/text-parsing/lib/helpers/parse-text.ts
+++ b/src/entities/text-parsing/lib/helpers/parse-text.ts
@@ -164,9 +164,11 @@ export const generateAttendanceInfo = (
   })
 
   if (Object.keys(attendanceInfo).length !== 7) {
+    const parsedDays = new Set(Object.keys(attendanceInfo))
+
     const missingDays: string[] = Object.entries(dayMapping)
-      .filter(([key]) => !Object.keys(attendanceInfo).includes(key))
-      .map(([, value]) => value)
+      .filter(([dayKey]) => !parsedDays.has(dayKey))
+      .map(([, mappedValue]) => mappedValue)
 
     const errorLineIndexArray = lines
       .map((line, idx) => (missingDays.some((day) => line.includes(day)) ? idx : null))

--- a/src/entities/text-parsing/model/index.ts
+++ b/src/entities/text-parsing/model/index.ts
@@ -1,2 +1,3 @@
 export * from './schema'
 export * from './text-parsing-state'
+export * from './text-parsing-exception'

--- a/src/entities/text-parsing/model/schema.ts
+++ b/src/entities/text-parsing/model/schema.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import type { TextParsingException } from './text-parsing-exception'
 import { AttendanceBadgeSchema } from '@/entities/attendance-badge/@x/text-parsing'
 import {
   AttendanceDetailOptionSchema,
@@ -75,3 +76,7 @@ export const ParsingResultSchema = z.object({
 export type ParsingResult = z.infer<typeof ParsingResultSchema>
 
 export type EditableParsingResult = Omit<ParsingResult, 'badgeId'> & { badgeId: number | null }
+
+export type EditableParsingResultWithError =
+  | { data: EditableParsingResult; error: null }
+  | { data: null; error: TextParsingException[] }

--- a/src/entities/text-parsing/model/text-parsing-exception.ts
+++ b/src/entities/text-parsing/model/text-parsing-exception.ts
@@ -1,42 +1,15 @@
 import { Exception } from '@/shared/api'
 
 export class TextParsingException extends Exception {
-  private _rawText: string
-  private _errorLineIndexArray?: number[]
-  private _errorLineNumberArray?: number[]
+  public rawText: string
+  public errorLineIndexArray?: number[]
 
   public constructor(cause: string, rawText: string, errorLineIndexArray?: number[]) {
     super(cause)
 
     this.name = this.constructor.name
 
-    this._rawText = rawText
-    this._errorLineIndexArray = errorLineIndexArray
-    this._errorLineNumberArray = errorLineIndexArray?.map((lineIndex) => lineIndex + 1)
-  }
-
-  public get rawText() {
-    return this._rawText
-  }
-
-  public set rawText(rawText: string) {
-    this._rawText = rawText
-  }
-
-  public get errorLineIndexArray() {
-    return this._errorLineIndexArray
-  }
-
-  public set errorLineIndexArray(errorLineIndexArray: number[] | undefined) {
-    this._errorLineIndexArray = errorLineIndexArray
-    this._errorLineNumberArray = errorLineIndexArray?.map((lineIndex) => lineIndex + 1)
-  }
-
-  public get errorLineNumberArray() {
-    return this._errorLineNumberArray
-  }
-
-  public set errorLineNumberArray(errorLineNumberArray: number[] | undefined) {
-    this._errorLineNumberArray = errorLineNumberArray
+    this.rawText = rawText
+    this.errorLineIndexArray = errorLineIndexArray
   }
 }

--- a/src/entities/text-parsing/model/text-parsing-exception.ts
+++ b/src/entities/text-parsing/model/text-parsing-exception.ts
@@ -1,0 +1,42 @@
+import { Exception } from '@/shared/api'
+
+export class TextParsingException extends Exception {
+  private _rawText: string
+  private _errorLineIndexArray?: number[]
+  private _errorLineNumberArray?: number[]
+
+  public constructor(cause: string, rawText: string, errorLineIndexArray?: number[]) {
+    super(cause)
+
+    this.name = this.constructor.name
+
+    this._rawText = rawText
+    this._errorLineIndexArray = errorLineIndexArray
+    this._errorLineNumberArray = errorLineIndexArray?.map((lineIndex) => lineIndex + 1)
+  }
+
+  public get rawText() {
+    return this._rawText
+  }
+
+  public set rawText(rawText: string) {
+    this._rawText = rawText
+  }
+
+  public get errorLineIndexArray() {
+    return this._errorLineIndexArray
+  }
+
+  public set errorLineIndexArray(errorLineIndexArray: number[] | undefined) {
+    this._errorLineIndexArray = errorLineIndexArray
+    this._errorLineNumberArray = errorLineIndexArray?.map((lineIndex) => lineIndex + 1)
+  }
+
+  public get errorLineNumberArray() {
+    return this._errorLineNumberArray
+  }
+
+  public set errorLineNumberArray(errorLineNumberArray: number[] | undefined) {
+    this._errorLineNumberArray = errorLineNumberArray
+  }
+}

--- a/src/entities/text-parsing/model/text-parsing-state.ts
+++ b/src/entities/text-parsing/model/text-parsing-state.ts
@@ -1,10 +1,10 @@
 import { create } from 'zustand'
-import type { EditableParsingResult, ParsingOptions } from './schema'
+import type { EditableParsingResultWithError, ParsingOptions } from './schema'
 
 export interface TextParsingState {
   text: string
   options: ParsingOptions | null
-  result: EditableParsingResult[]
+  result: EditableParsingResultWithError[]
 }
 
 export interface TextParsingStore extends TextParsingState {
@@ -12,7 +12,7 @@ export interface TextParsingStore extends TextParsingState {
     resetTextParsingStore: () => void
     setText: (text: string) => void
     setOptions: (options: ParsingOptions | null) => void
-    setResult: (result: EditableParsingResult[]) => void
+    setResult: (result: EditableParsingResultWithError[]) => void
   }
 }
 
@@ -29,7 +29,7 @@ export const useTextParsingStore = create<TextParsingStore>()((set) => ({
     resetTextParsingStore: () => set(initialState),
     setText: (text: string) => set({ text }),
     setOptions: (options: ParsingOptions | null) => set({ options }),
-    setResult: (result: EditableParsingResult[]) => set({ result }),
+    setResult: (result: EditableParsingResultWithError[]) => set({ result }),
   },
 }))
 

--- a/src/views/text-parsing/lib/helpers/parse-text-safely.ts
+++ b/src/views/text-parsing/lib/helpers/parse-text-safely.ts
@@ -22,10 +22,6 @@ export const parseTextSafely = ({
   try {
     const result = parseText(text, parsingOptions, attendanceOptions, badgeList)
 
-    if (result.length < 1) {
-      throw new Exception('입력된 원본 텍스트의 형식을 확인해주세요')
-    }
-
     useTextParsingStore.setState((state) => ({ ...state, result: result }))
 
     onSuccess?.()

--- a/src/views/text-parsing/ui/text-parsing-input.tsx
+++ b/src/views/text-parsing/ui/text-parsing-input.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Button, Textarea } from '@mantine/core'
+import { Button, Group, Textarea } from '@mantine/core'
 import toast from 'react-hot-toast'
 import { useAttendanceBadgeListWithConditionsQuery } from '@/entities/attendance-badge'
 import { useAttendanceOptionListSuspenseQuery } from '@/entities/attendance-option'
@@ -21,7 +21,12 @@ export const TextParsingInput: React.FC = () => {
   const options = useParsingOptions()
   const isSubmitting = useIsTextParsingMutating()
 
-  const { setText } = useTextParsingActions()
+  const { setText, setResult } = useTextParsingActions()
+
+  const handleResetText = () => {
+    setText('')
+    setResult([])
+  }
 
   const handleParsingText = () => {
     if (options) {
@@ -42,9 +47,14 @@ export const TextParsingInput: React.FC = () => {
           <Icon query="fluent-emoji:books" className="mr-2" />
           텍스트 분석
         </AdminTitle>
-        <Button onClick={handleParsingText} disabled={!text.trim() || isSubmitting}>
-          분석하기
-        </Button>
+        <Group gap="xs" className="flex-1" justify="flex-end" wrap="nowrap">
+          <Button onClick={handleResetText} variant="light" disabled={!text.trim() || isSubmitting}>
+            초기화
+          </Button>
+          <Button onClick={handleParsingText} disabled={!text.trim() || isSubmitting}>
+            분석하기
+          </Button>
+        </Group>
       </div>
       <Textarea
         label="원본 텍스트"

--- a/src/views/text-parsing/ui/text-parsing-result-error-fallback.stories.tsx
+++ b/src/views/text-parsing/ui/text-parsing-result-error-fallback.stories.tsx
@@ -1,0 +1,57 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { ATTENDANCE_BADGE_MOCK_DATA } from '@/entities/attendance-badge'
+import { OPTION_LIST_MOCK_DATA } from '@/entities/attendance-option'
+import { parseText, PARSING_OPTIONS_MOCK_DATA } from '@/entities/text-parsing'
+import { TextParsingResultErrorFallback } from './text-parsing-result-fallback-ui'
+
+const text = `홍길동 — 2025-03-31 오전 9:48
+이름 홍길동
+이번 주 한 마디: 파이팅
+
+월:🎖️
+프로젝트 기능 구현
+화🎖️
+프로젝트 기능 구현
+수:🌱
+프로젝트 기능 리팩토링
+이력서 수정
+목:🎖️
+프로젝트 PR 리뷰 반영 및 수정
+포트폴리오 수정
+금🎖️
+프로젝트 PR 리뷰 반영 및 수정
+포트폴리오 수정
+
+토:🌱
+포트폴리오 수정
+일:🌱`
+
+const meta: Meta<typeof TextParsingResultErrorFallback> = {
+  title: '관리자 페이지/출석 관리/텍스트 분석 및 적용/텍스트 분석 결과 폼 대체 UI - 에러',
+  component: TextParsingResultErrorFallback,
+  parameters: {
+    nextjs: {
+      appDirectory: true,
+    },
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof TextParsingResultErrorFallback>
+
+export const 텍스트_파싱_예외: Story = {
+  render: (arg) => {
+    const errorList = parseText(
+      text,
+      PARSING_OPTIONS_MOCK_DATA,
+      OPTION_LIST_MOCK_DATA,
+      ATTENDANCE_BADGE_MOCK_DATA,
+    )[0].error!
+
+    return (
+      <div className="mx-auto w-[700px] rounded-lg border border-solid border-gray-300 p-4 @container/parsing-result dark:border-dark-400">
+        <TextParsingResultErrorFallback {...arg} errorList={errorList} />
+      </div>
+    )
+  },
+}

--- a/src/views/text-parsing/ui/text-parsing-result-fallback-ui.tsx
+++ b/src/views/text-parsing/ui/text-parsing-result-fallback-ui.tsx
@@ -1,0 +1,44 @@
+import { Text } from '@mantine/core'
+import { DEFAULT_LINE_DELIMITER, TextParsingException } from '@/entities/text-parsing'
+import { cn } from '@/shared/lib'
+import { Icon } from '@/shared/ui'
+
+export interface TextParsingResultErrorFallbackProps {
+  errorList: TextParsingException[]
+}
+
+export const TextParsingResultErrorFallback: React.FC<TextParsingResultErrorFallbackProps> = ({
+  errorList,
+}) => {
+  const lines = errorList[0].rawText.split(DEFAULT_LINE_DELIMITER)
+  const errorLineIndexList = errorList.flatMap((error) => error.errorLineIndexArray)
+
+  return (
+    <div className="flex flex-col items-center gap-3 pt-3">
+      <Icon query="fluent:warning-28-regular" className="size-20" />
+      <div className="space-y-0 text-center">
+        {errorList.map((error) => (
+          <Text key={TextParsingException.extractMessage(error)} className="font-medium">
+            {error.errorLineNumberArray && `[${error.errorLineNumberArray?.join(', ')}행] `}
+            {TextParsingException.extractMessage(error)}
+          </Text>
+        ))}
+      </div>
+      <div className="mt-2 max-h-56 w-full overflow-auto rounded-md border border-solid border-red-300 bg-red-100 py-2 text-sm dark:border-rose-200/20 dark:bg-rose-300/20">
+        {lines.map((line, idx) => (
+          <div
+            key={idx}
+            className={cn('flex pl-3', {
+              'bg-red-300 dark:bg-rose-600/30': errorLineIndexList.includes(idx),
+            })}
+          >
+            <div className="w-6 flex-none pr-2 text-right font-mono text-dark-300 dark:text-dark-200">
+              {idx + 1}
+            </div>
+            <span className="text-dark-900 dark:text-dark-50">{line}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/views/text-parsing/ui/text-parsing-result-fallback-ui.tsx
+++ b/src/views/text-parsing/ui/text-parsing-result-fallback-ui.tsx
@@ -33,7 +33,8 @@ export const TextParsingResultErrorFallback: React.FC<TextParsingResultErrorFall
             component="li"
           >
             {TextParsingException.extractMessage(error)}
-            {error.errorLineNumberArray && ` (${error.errorLineNumberArray.join(', ')}행)`}
+            {error.errorLineIndexArray &&
+              ` (${error.errorLineIndexArray.map((index) => index + 1).join(', ')}행)`}
           </List.Item>
         ))}
       </List>

--- a/src/views/text-parsing/ui/text-parsing-result-fallback-ui.tsx
+++ b/src/views/text-parsing/ui/text-parsing-result-fallback-ui.tsx
@@ -1,4 +1,4 @@
-import { Text } from '@mantine/core'
+import { List } from '@mantine/core'
 import { DEFAULT_LINE_DELIMITER, TextParsingException } from '@/entities/text-parsing'
 import { cn } from '@/shared/lib'
 import { Icon } from '@/shared/ui'
@@ -11,34 +11,47 @@ export const TextParsingResultErrorFallback: React.FC<TextParsingResultErrorFall
   errorList,
 }) => {
   const lines = errorList[0].rawText.split(DEFAULT_LINE_DELIMITER)
-  const errorLineIndexList = errorList.flatMap((error) => error.errorLineIndexArray)
+  const errorLineIndexList = new Set(errorList.flatMap((error) => error.errorLineIndexArray ?? []))
 
   return (
-    <div className="flex flex-col items-center gap-3 pt-3">
-      <Icon query="fluent:warning-28-regular" className="size-20" />
-      <div className="space-y-0 text-center">
-        {errorList.map((error) => (
-          <Text key={TextParsingException.extractMessage(error)} className="font-medium">
-            {error.errorLineNumberArray && `[${error.errorLineNumberArray?.join(', ')}행] `}
-            {TextParsingException.extractMessage(error)}
-          </Text>
-        ))}
+    <div className="space-y-3 py-1">
+      <div className="flex space-x-2">
+        <Icon query="fluent:warning-28-regular" className="mt-0.5 size-5" />
+        <p className="break-keep font-bold">아래의 이유로 텍스트 파싱에 실패했어요</p>
       </div>
-      <div className="mt-2 max-h-56 w-full overflow-auto rounded-md border border-solid border-red-300 bg-red-100 py-2 text-sm dark:border-rose-200/20 dark:bg-rose-300/20">
+      <List
+        className="space-y-0 pl-3"
+        icon={
+          <span className="block size-1.5 rounded-full bg-[var(--mantine-color-placeholder)]" />
+        }
+        component="ul"
+      >
+        {errorList.map((error) => (
+          <List.Item
+            key={TextParsingException.extractMessage(error)}
+            className="break-keep font-medium"
+            component="li"
+          >
+            {TextParsingException.extractMessage(error)}
+            {error.errorLineNumberArray && ` (${error.errorLineNumberArray.join(', ')}행)`}
+          </List.Item>
+        ))}
+      </List>
+      <pre className="mt-2 max-h-56 w-full overflow-auto rounded-md border border-solid border-red-300 bg-[var(--mantine-color-red-light)] py-2 text-sm dark:border-red-900">
         {lines.map((line, idx) => (
-          <div
+          <span
             key={idx}
             className={cn('flex pl-3', {
-              'bg-red-300 dark:bg-rose-600/30': errorLineIndexList.includes(idx),
+              'bg-[var(--mantine-color-red-light-hover)]': errorLineIndexList.has(idx),
             })}
           >
-            <div className="w-6 flex-none pr-2 text-right font-mono text-dark-300 dark:text-dark-200">
+            <span className="w-6 flex-none pr-2 text-right font-mono text-dark-300 dark:text-dark-200">
               {idx + 1}
-            </div>
+            </span>
             <span className="text-dark-900 dark:text-dark-50">{line}</span>
-          </div>
+          </span>
         ))}
-      </div>
+      </pre>
     </div>
   )
 }

--- a/src/views/text-parsing/ui/text-parsing-result-form-fields.tsx
+++ b/src/views/text-parsing/ui/text-parsing-result-form-fields.tsx
@@ -1,0 +1,210 @@
+import {
+  ActionIcon,
+  CopyButton,
+  Group,
+  Paper,
+  Select,
+  Table,
+  TextInput,
+  Title,
+} from '@mantine/core'
+import type { UseFormReturnType } from '@mantine/form'
+import { AttendanceOptionSelect } from '@/widgets/attendance-options-select'
+import type { GetAttendanceBadgeListWithConditionsResponseData } from '@/entities/attendance-badge'
+import { useAttendanceOptionListSuspenseQuery } from '@/entities/attendance-option'
+import type { DayKey, EditableParsingResultWithError } from '@/entities/text-parsing'
+import {
+  DAY_OPTIONS_LABEL,
+  getAttendanceBadgeId,
+  transformAttendanceInfoToStatistic,
+  useParsingResult,
+} from '@/entities/text-parsing'
+import { Icon } from '@/shared/ui'
+import { TextParsingResultStatistic } from './text-parsing-result-statistic'
+
+export interface TextParsingResultFormFieldsProps {
+  form: Omit<
+    UseFormReturnType<{ result: EditableParsingResultWithError[] }>,
+    'setInitialValues' | 'reset'
+  >
+  setInitialValues: (values: { result: EditableParsingResultWithError[] }) => void
+  personResult: EditableParsingResultWithError
+  personResultIndex: number
+  badgeOptions: GetAttendanceBadgeListWithConditionsResponseData
+}
+
+export const TextParsingResultFormFields: React.FC<TextParsingResultFormFieldsProps> = ({
+  form,
+  setInitialValues,
+  personResult,
+  personResultIndex,
+  badgeOptions,
+}) => {
+  const { data: attendanceOptions } = useAttendanceOptionListSuspenseQuery()
+
+  const result = useParsingResult()
+
+  if (!personResult || !personResult.data) {
+    return null
+  }
+
+  return (
+    <>
+      <Group gap="md">
+        <TextInput
+          label="이름"
+          className="w-40"
+          classNames={{ label: 'mb-2 font-semibold' }}
+          key={form.key(`result.${personResultIndex}.data.name`)}
+          {...form.getInputProps(`result.${personResultIndex}.data.name`)}
+        />
+        <Group gap="0.325rem" wrap="nowrap" align="flex-end">
+          <Select
+            label={`적용 배지${form.isDirty(`result.${personResultIndex}.data.badgeId`) ? ' (동기화 해제됨)' : ''}`}
+            className="w-40"
+            classNames={{ label: 'mb-2 pt-0.5' }}
+            data={badgeOptions.map(({ id, name, icon }) => ({
+              value: id.toString(),
+              label: `${icon} ${name}`,
+            }))}
+            value={personResult.data.badgeId?.toString()}
+            onChange={(value) => {
+              const updatedBadgeId = Number(value)
+              const targetStatistic = transformAttendanceInfoToStatistic(
+                personResult.data.attendanceInfo,
+                attendanceOptions,
+              )
+              const computedBadgeId = getAttendanceBadgeId(targetStatistic, badgeOptions)
+
+              if (updatedBadgeId === computedBadgeId) {
+                setInitialValues({
+                  result: result.map((initialPerson) => {
+                    if (initialPerson.data?.name === personResult.data.name) {
+                      return {
+                        ...initialPerson,
+                        data: {
+                          ...initialPerson.data,
+                          badgeId: updatedBadgeId,
+                        },
+                      } as EditableParsingResultWithError
+                    }
+
+                    return initialPerson
+                  }),
+                })
+              }
+
+              form.setFieldValue(`result.${personResultIndex}.data.badgeId`, updatedBadgeId)
+            }}
+            checkIconPosition="right"
+            allowDeselect={false}
+          />
+          <CopyButton
+            value={badgeOptions.find(({ id }) => id === personResult.data.badgeId)?.icon || ''}
+          >
+            {({ copied, copy }) => (
+              <ActionIcon
+                title="배지 아이콘 복사하기"
+                variant="default"
+                size="input-sm"
+                onClick={copy}
+              >
+                <Icon
+                  query={copied ? 'fluent:checkmark-16-regular' : 'fluent:copy-16-regular'}
+                  className="text-[var(--mantine-color-text)]"
+                />
+              </ActionIcon>
+            )}
+          </CopyButton>
+        </Group>
+      </Group>
+      <div className="mt-8 flex flex-col items-start gap-x-4 gap-y-8 @xl/parsing-result:flex-row">
+        <div className="flex-1">
+          <Title order={4} className="mb-2 flex items-center text-base font-semibold">
+            <Icon query="fluent-emoji:spiral-calendar" className="mr-2" />
+            출석 정보
+          </Title>
+          <Paper withBorder className="overflow-hidden">
+            <Table
+              layout="fixed"
+              withColumnBorders
+              classNames={{ th: 'w-20 font-normal', td: 'h-14' }}
+            >
+              <Table.Tbody>
+                {Object.entries(personResult.data.attendanceInfo).map(([day, info]) => (
+                  <Table.Tr key={day}>
+                    <Table.Th>{DAY_OPTIONS_LABEL[day as DayKey]}</Table.Th>
+                    <Table.Td>
+                      <AttendanceOptionSelect
+                        className="w-40"
+                        attendanceOptions={attendanceOptions}
+                        value={info}
+                        onChange={(updatedDayInfo) => {
+                          const updatedAttendanceInfo = {
+                            ...personResult.data.attendanceInfo,
+                            data: {
+                              [day]: updatedDayInfo,
+                            },
+                          }
+
+                          const updatedStatistic = transformAttendanceInfoToStatistic(
+                            updatedAttendanceInfo,
+                            attendanceOptions,
+                          )
+                          const updatedBadgeId = getAttendanceBadgeId(
+                            updatedStatistic,
+                            badgeOptions,
+                          )
+
+                          form.setFieldValue(
+                            `result.${personResultIndex}.data.attendanceStatistic`,
+                            updatedStatistic,
+                          )
+                          form.setFieldValue(
+                            `result.${personResultIndex}.data.attendanceInfo.${day}`,
+                            updatedDayInfo,
+                          )
+
+                          if (
+                            !form.isDirty(`result.${personResultIndex}.data.badgeId`) ||
+                            updatedBadgeId === personResult.data.badgeId
+                          ) {
+                            setInitialValues({
+                              result: result.map((initialPerson) => {
+                                if (initialPerson.data?.name === personResult.data.name) {
+                                  return {
+                                    ...initialPerson,
+                                    data: {
+                                      ...initialPerson.data,
+                                      badgeId: updatedBadgeId,
+                                      attendanceInfo: updatedAttendanceInfo,
+                                      attendanceStatistic: updatedStatistic,
+                                    },
+                                  } as EditableParsingResultWithError
+                                }
+
+                                return initialPerson
+                              }),
+                            })
+                            form.setFieldValue(
+                              `result.${personResultIndex}.data.badgeId`,
+                              updatedBadgeId,
+                            )
+                          }
+                        }}
+                      />
+                    </Table.Td>
+                  </Table.Tr>
+                ))}
+              </Table.Tbody>
+            </Table>
+          </Paper>
+        </div>
+        <TextParsingResultStatistic
+          attendanceStatistic={personResult.data.attendanceStatistic}
+          className="flex-1"
+        />
+      </div>
+    </>
+  )
+}

--- a/src/views/text-parsing/ui/text-parsing-result-form-fields.tsx
+++ b/src/views/text-parsing/ui/text-parsing-result-form-fields.tsx
@@ -120,7 +120,7 @@ export const TextParsingResultFormFields: React.FC<TextParsingResultFormFieldsPr
       </Group>
       <div className="mt-8 flex flex-col items-start gap-x-4 gap-y-8 @xl/parsing-result:flex-row">
         <div className="flex-1">
-          <Title order={4} className="mb-2 flex items-center text-base font-semibold">
+          <Title order={4} className="mb-2 flex items-center text-sm font-semibold">
             <Icon query="fluent-emoji:spiral-calendar" className="mr-2" />
             출석 정보
           </Title>

--- a/src/views/text-parsing/ui/text-parsing-result-form.tsx
+++ b/src/views/text-parsing/ui/text-parsing-result-form.tsx
@@ -1,34 +1,19 @@
 'use client'
 
-import {
-  ActionIcon,
-  CopyButton,
-  Group,
-  Paper,
-  Select,
-  Table,
-  TextInput,
-  Title,
-} from '@mantine/core'
 import { useForm } from '@mantine/form'
 import { useEffect } from 'react'
 import toast from 'react-hot-toast'
-import { AttendanceOptionSelect } from '@/widgets/attendance-options-select'
 import type { GetAttendanceBadgeListWithConditionsResponseData } from '@/entities/attendance-badge'
-import { useAttendanceOptionListSuspenseQuery } from '@/entities/attendance-option'
 import {
-  type DayKey,
   type EditableParsingResult,
   type PostTextParsingResult,
-  DAY_OPTIONS_LABEL,
-  getAttendanceBadgeId,
-  transformAttendanceInfoToStatistic,
   useParsingResult,
   useIsTextParsingMutating,
 } from '@/entities/text-parsing'
 import { omit } from '@/shared/lib'
-import { Icon } from '@/shared/ui'
-import { TextParsingResultStatistic } from './text-parsing-result-statistic'
+import { FallbackRender } from '@/shared/ui'
+import { TextParsingResultErrorFallback } from './text-parsing-result-fallback-ui'
+import { TextParsingResultFormFields } from './text-parsing-result-form-fields'
 
 export const TEXT_PARSING_RESULT_FORM_ID = 'parsing-result-form'
 
@@ -41,8 +26,6 @@ export const TextParsingResultForm: React.FC<TextParsingResultFormProps> = ({
   badgeOptions,
   team,
 }) => {
-  const { data: attendanceOptions } = useAttendanceOptionListSuspenseQuery()
-
   const result = useParsingResult()
 
   const isSubmitting = useIsTextParsingMutating()
@@ -93,156 +76,28 @@ export const TextParsingResultForm: React.FC<TextParsingResultFormProps> = ({
   return (
     <form
       id={TEXT_PARSING_RESULT_FORM_ID}
-      onSubmit={form.onSubmit(({ result }) => handleSave(result))}
+      onSubmit={form.onSubmit(({ result }) =>
+        handleSave(result.map((res) => res.data as EditableParsingResult)),
+      )}
       className="space-y-4"
     >
       {form.values.result.map((person, personIndex) => (
         <div
           className="rounded-lg border border-solid border-gray-300 p-4 @container/parsing-result dark:border-dark-400"
-          key={person.name}
+          key={personIndex}
         >
-          <Group gap="md">
-            <TextInput
-              label="이름"
-              className="w-40"
-              classNames={{ label: 'mb-2 font-semibold' }}
-              key={form.key(`result.${personIndex}.name`)}
-              {...form.getInputProps(`result.${personIndex}.name`)}
+          <FallbackRender
+            render={!person.data}
+            component={<TextParsingResultErrorFallback errorList={person.error!} />}
+          >
+            <TextParsingResultFormFields
+              form={form}
+              setInitialValues={setInitialValues}
+              personResult={person}
+              personResultIndex={personIndex}
+              badgeOptions={badgeOptions}
             />
-            <Group gap="0.325rem" wrap="nowrap" align="flex-end">
-              <Select
-                label={`적용 배지${form.isDirty(`result.${personIndex}.badgeId`) ? ' (동기화 해제됨)' : ''}`}
-                className="w-40"
-                classNames={{ label: 'mb-2 pt-0.5' }}
-                data={badgeOptions.map(({ id, name, icon }) => ({
-                  value: id.toString(),
-                  label: `${icon} ${name}`,
-                }))}
-                value={person.badgeId?.toString()}
-                onChange={(value) => {
-                  const updatedBadgeId = Number(value)
-                  const targetStatistic = transformAttendanceInfoToStatistic(
-                    person.attendanceInfo,
-                    attendanceOptions,
-                  )
-                  const computedBadgeId = getAttendanceBadgeId(targetStatistic, badgeOptions)
-
-                  if (updatedBadgeId === computedBadgeId) {
-                    setInitialValues({
-                      result: result.map((initialPerson) => {
-                        if (initialPerson.name === person.name) {
-                          return {
-                            ...initialPerson,
-                            badgeId: updatedBadgeId,
-                          }
-                        }
-
-                        return initialPerson
-                      }),
-                    })
-                  }
-
-                  form.setFieldValue(`result.${personIndex}.badgeId`, updatedBadgeId)
-                }}
-                checkIconPosition="right"
-                allowDeselect={false}
-              />
-              <CopyButton value={badgeOptions.find(({ id }) => id === person.badgeId)?.icon || ''}>
-                {({ copied, copy }) => (
-                  <ActionIcon
-                    title="배지 아이콘 복사하기"
-                    variant="default"
-                    size="input-sm"
-                    onClick={copy}
-                  >
-                    <Icon
-                      query={copied ? 'fluent:checkmark-16-regular' : 'fluent:copy-16-regular'}
-                      className="text-[var(--mantine-color-text)]"
-                    />
-                  </ActionIcon>
-                )}
-              </CopyButton>
-            </Group>
-          </Group>
-          <div className="mt-8 flex flex-col items-start gap-x-4 gap-y-8 @xl/parsing-result:flex-row">
-            <div className="flex-1">
-              <Title order={4} className="mb-2 flex items-center text-base font-semibold">
-                <Icon query="fluent-emoji:spiral-calendar" className="mr-2" />
-                출석 정보
-              </Title>
-              <Paper withBorder className="overflow-hidden">
-                <Table
-                  layout="fixed"
-                  withColumnBorders
-                  classNames={{ th: 'w-20 font-normal', td: 'h-14' }}
-                >
-                  <Table.Tbody>
-                    {Object.entries(person.attendanceInfo).map(([day, info]) => (
-                      <Table.Tr key={day}>
-                        <Table.Th>{DAY_OPTIONS_LABEL[day as DayKey]}</Table.Th>
-                        <Table.Td>
-                          <AttendanceOptionSelect
-                            className="w-40"
-                            attendanceOptions={attendanceOptions}
-                            value={info}
-                            onChange={(updatedDayInfo) => {
-                              const updatedAttendanceInfo = {
-                                ...person.attendanceInfo,
-                                [day]: updatedDayInfo,
-                              }
-
-                              const updatedStatistic = transformAttendanceInfoToStatistic(
-                                updatedAttendanceInfo,
-                                attendanceOptions,
-                              )
-                              const updatedBadgeId = getAttendanceBadgeId(
-                                updatedStatistic,
-                                badgeOptions,
-                              )
-
-                              form.setFieldValue(
-                                `result.${personIndex}.attendanceStatistic`,
-                                updatedStatistic,
-                              )
-                              form.setFieldValue(
-                                `result.${personIndex}.attendanceInfo.${day}`,
-                                updatedDayInfo,
-                              )
-
-                              if (
-                                !form.isDirty(`result.${personIndex}.badgeId`) ||
-                                updatedBadgeId === person.badgeId
-                              ) {
-                                setInitialValues({
-                                  result: result.map((initialPerson) => {
-                                    if (initialPerson.name === person.name) {
-                                      return {
-                                        ...initialPerson,
-                                        badgeId: updatedBadgeId,
-                                        attendanceInfo: updatedAttendanceInfo,
-                                        attendanceStatistic: updatedStatistic,
-                                      }
-                                    }
-
-                                    return initialPerson
-                                  }),
-                                })
-                                form.setFieldValue(`result.${personIndex}.badgeId`, updatedBadgeId)
-                              }
-                            }}
-                          />
-                        </Table.Td>
-                      </Table.Tr>
-                    ))}
-                  </Table.Tbody>
-                </Table>
-              </Paper>
-            </div>
-            <TextParsingResultStatistic
-              attendanceStatistic={person.attendanceStatistic}
-              className="flex-1"
-            />
-          </div>
+          </FallbackRender>
         </div>
       ))}
     </form>

--- a/src/views/text-parsing/ui/text-parsing-result-statistic.tsx
+++ b/src/views/text-parsing/ui/text-parsing-result-statistic.tsx
@@ -16,7 +16,7 @@ export const TextParsingResultStatistic: React.FC<TextParsingResultStatisticProp
 
   return (
     <div {...props}>
-      <Title order={4} className="mb-2 flex items-center text-base font-semibold">
+      <Title order={4} className="mb-2 flex items-center text-sm font-semibold">
         <Icon query="fluent-emoji:bar-chart" className="mr-2" />
         출석 통계
       </Title>

--- a/src/views/text-parsing/ui/text-parsing-result.tsx
+++ b/src/views/text-parsing/ui/text-parsing-result.tsx
@@ -41,7 +41,12 @@ export const TextParsingResult: React.FC = () => {
           <Button
             form={TEXT_PARSING_RESULT_FORM_ID}
             type="submit"
-            disabled={result.length <= 0 || !team || isSubmitting}
+            disabled={
+              result.length <= 0 ||
+              result.filter((res) => res.error).length > 0 ||
+              !team ||
+              isSubmitting
+            }
           >
             반영하기
           </Button>


### PR DESCRIPTION
## 📑 PR 유형

<!-- 해당하는 유형에 X를 입력해주세요 (복수 가능) -->

- [ ] 🚨 버그 수정
- [x] 🔧 기능의 추가
- [ ] ✨ 코드 작성 양식의 변경 (포맷팅, 변수 이름 변경)
- [ ] 📚 리팩토링 (기능 또는 API 변경이 없는 경우)
- [ ] 🔨 빌드 관련 수정
- [ ] 💼 CI 관련 수정
- [ ] 📄 문서의 수정
- [ ] 🎸 기타

<br />

## 🌿 반영 브랜치 (리마인드 용도)

<!-- ex) feature/login => dev -->

```
feature/text-parsing => dev
```

<br />

## 🎨 작업 내용
- 텍스트 파싱 인풋 및 결과 폼 초기화 버튼 추가
- 텍스트 파싱 예외 메시지 구체화
- 텍스트 파싱 예외 대체 UI 로직 추가
- 텍스트 파싱 예외 대체 UI 스토리 추가
- 텍스트 파싱 결과 폼 필드 라벨 폰트 크기 통일

<br />

## 🖥️ 실행 화면

https://github.com/user-attachments/assets/95b8a8ac-c3c5-423f-976f-e87806e6d71a

![image](https://github.com/user-attachments/assets/9c531e1b-89c2-4a0d-a4e4-443bd5cf2fbe)


<br />

## 🔑 관련 이슈 번호
[MOJI-34](https://itmoji.atlassian.net/browse/MOJI-34?atlOrigin=eyJpIjoiMDkwN2Q0YzhjNmE3NDRhM2EyYzQ0Y2IwMjdhOTZmZTciLCJwIjoiaiJ9)

<br />

## 🤝🏻 해당 부분을 중점적으로 리뷰해주세요!
- Mantine 색상 확장 관련
  - 현재 Mantine의 색상을 Tailwind에 확장해 사용 중인데, Mantine CSS 변수들이 hex 값(ex: `--mantine-color-red-0: #fff5f5`)으로 정의되어 있어 `bg-red-500/50`처럼 opacity 축약형 클래스 사용이 불가능한 문제가 있었습니다.
  - opacity를 직접 지정해 투명도를 조절하려 했지만 [린트 에러](https://github.com/francoismassart/eslint-plugin-tailwindcss/blob/master/docs/rules/migration-from-tailwind-2.md)가 발생했고, 권장되지 않는 방식이라 판단하여 TextParsingResultErrorFallback 컴포넌트의 다크 모드에서는 `red` 대신 `rose` 컬러를 임시로 사용했습니다.
  - 해결 방안으로는
    1. Mantine 컬러 CSS 변수를 rgb 기반으로 수정하거나
    2. 린트 설정을 조정해 예외를 허용하는 방식이 있을 것 같습니다.
  - 저는 이후 유지보수를 고려하면 번거롭더라도 1번 방식이 깔끔할 것 같다고 생각합니다. 관련해서 의견 주시면 감사하겠습니다!
- TextParsingException 관련
  - 기존 텍스트 파싱 로직은 파싱 중 예외가 발생 즉시 `throw`하는 구조였으나, 파싱 중 거치는 각 단계가 서로 독립적이라는 점을 고려해 일부 과정에서 예외가 발생하더라도 다음 과정을 계속 진행하고, 발생한 예외들을 모아 대체 UI 컴포넌트에서 한 번에 표시하는 방식으로 리팩토링했습니다.
  - TextParsingException을 단순히 타입으로만 처리할 수도 있었지만, 
    - 기존 로직의 반환 타입을 모두 변경해야 하고  
    - 관련 테스트 코드 또한 대거 수정이 필요한 상황이었기 때문에
    예외의 의미를 유지하면서도 기존 흐름에 최소한의 영향을 주기 위해 `Exception`을 확장한 커스텀 예외 클래스로 구현했습니다.
  - 관련해 궁금하신 점이나 개선 아이디어가 있다면 편하게 코멘트 남겨주세요.

<br />


[MOJI-34]: https://itmoji.atlassian.net/browse/MOJI-34?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ